### PR TITLE
Automatic consistent code format with clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+---
+BasedOnStyle: Google
+Language: JavaScript
+ColumnLimit: 150
+...

--- a/background.js
+++ b/background.js
@@ -1,36 +1,34 @@
-chrome.storage.local.get('smdata', function(data){
-　// 初期値
+chrome.storage.local.get('smdata', function(data) {
+  // 初期値
   var smdata = {};
   smdata.sumPx = 0;
   smdata.startDate = new Date();
   smdata.startDate = smdata.startDate.toString();
 
-  if (data.smdata === undefined){
-    chrome.storage.local.set({smdata: smdata}, function(){});
+  if (data.smdata === undefined) {
+    chrome.storage.local.set({smdata: smdata}, function() {});
   } else {
-    if(data.smdata.sumPx !== undefined){
-    // データが保存されていたら、そのデータを代入
-    smdata.sumPx = data.smdata.sumPx;
-    smdata.startDate = data.smdata.startDate;
+    if (data.smdata.sumPx !== undefined) {
+      // データが保存されていたら、そのデータを代入
+      smdata.sumPx = data.smdata.sumPx;
+      smdata.startDate = data.smdata.startDate;
     }
   }
   // スクロールイベントが走ったら、データを更新
-  chrome.runtime.onMessage.addListener(
-  function(request, sender, sendResponse) {
-    if (request.px !== 'undefined'){
+  chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+    if (request.px !== 'undefined') {
       smdata.sumPx += request.px;
-        chrome.storage.local.set({smdata: smdata}, function(){});
+      chrome.storage.local.set({smdata: smdata}, function() {});
       sendResponse({sum: smdata.sumPx, date: smdata.startDate});
     }
-  }
-  );
+  });
 
   // タブを更新 or 開いたら実行される
-  chrome.tabs.onUpdated.addListener(function(tabid, info, tab){
-    if(info.status === 'complete'){
-    chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
-      chrome.tabs.sendMessage(tabid, {start: 'start', sum: smdata.sumPx, date: smdata.startDate}, function(response) {});
-    });
+  chrome.tabs.onUpdated.addListener(function(tabid, info, tab) {
+    if (info.status === 'complete') {
+      chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+        chrome.tabs.sendMessage(tabid, {start: 'start', sum: smdata.sumPx, date: smdata.startDate}, function(response) {});
+      });
     }
   });
 
@@ -47,5 +45,3 @@ chrome.storage.local.get('smdata', function(data){
     });
   });
 });
-
-

--- a/background.js
+++ b/background.js
@@ -5,10 +5,10 @@ chrome.storage.local.get('smdata', function(data){
   smdata.startDate = new Date();
   smdata.startDate = smdata.startDate.toString();
 
-  if (data.smdata == undefined){
+  if (data.smdata === undefined){
     chrome.storage.local.set({smdata: smdata}, function(){});
   } else {
-    if(data.smdata.sumPx != undefined){
+    if(data.smdata.sumPx !== undefined){
     // データが保存されていたら、そのデータを代入
     smdata.sumPx = data.smdata.sumPx;
     smdata.startDate = data.smdata.startDate;
@@ -17,7 +17,7 @@ chrome.storage.local.get('smdata', function(data){
   // スクロールイベントが走ったら、データを更新
   chrome.runtime.onMessage.addListener(
   function(request, sender, sendResponse) {
-    if (request.px != 'undefined'){
+    if (request.px !== 'undefined'){
       smdata.sumPx += request.px;
         chrome.storage.local.set({smdata: smdata}, function(){});
       sendResponse({sum: smdata.sumPx, date: smdata.startDate});
@@ -27,7 +27,7 @@ chrome.storage.local.get('smdata', function(data){
 
   // タブを更新 or 開いたら実行される
   chrome.tabs.onUpdated.addListener(function(tabid, info, tab){
-    if(info.status == 'complete'){
+    if(info.status === 'complete'){
     chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
       chrome.tabs.sendMessage(tabid, {start: 'start', sum: smdata.sumPx, date: smdata.startDate}, function(response) {});
     });

--- a/content.js
+++ b/content.js
@@ -91,7 +91,7 @@ $(function(){
 
   chrome.runtime.onMessage.addListener(
     function(request, sender, sendResponse) {
-      if (request.start == 'start'){
+      if (request.start === 'start'){
         startTime = Date.parse(request.date);
         sumPx = request.sum;
         init();

--- a/content.js
+++ b/content.js
@@ -1,5 +1,5 @@
-$(function(){
-  var goalPx = 159477367; // 42.195km
+$(function() {
+  var goalPx = 159477367;  // 42.195km
   var lastPx = 0;
   var pointerX = 0;
   var pointerY = 0;
@@ -8,24 +8,24 @@ $(function(){
   var startTime, sumPx;
 
   // スタートしてから今までの時間を計算する
-  function currentRecord(){
+  function currentRecord() {
     var nowTime = new Date();
     var time = nowTime - startTime;
     var hours = Math.floor(time / (60 * 60 * 1000));
-    var minutes = Math.floor(time / (60 * 1000)) % 60; 
+    var minutes = Math.floor(time / (60 * 1000)) % 60;
     var seconds = Math.floor(time / 1000) % 60 % 60;
     return hours.toString() + ':' + minutes.toString() + ':' + seconds.toString();
   }
 
   // ピクセルをメートル法に
-  function pixelToMetric(px){
+  function pixelToMetric(px) {
     var mm = px * 0.264583;
-    if (mm < 10){
+    if (mm < 10) {
       return mm.toFixed(1).toString() + 'mm'
-    } else if (mm < 1000){
+    } else if (mm < 1000) {
       var cm = mm / 10;
-      return  cm.toFixed(2).toString() + 'cm';
-    } else if (mm < 1000000){
+      return cm.toFixed(2).toString() + 'cm';
+    } else if (mm < 1000000) {
       var m = mm / 1000;
       return m.toFixed(2).toString() + 'm';
     } else {
@@ -33,23 +33,23 @@ $(function(){
       return km.toFixed(2).toString() + 'km';
     }
   }
-  
+
   // ログの表示
-  function showLog(){
+  function showLog() {
     $('#sm-counter').css('position', 'fixed');
     $('#sm-counter').css('top', pointerY);
     $('#sm-counter').css('left', pointerX);
   }
 
   // マウスが動いたら
-  $(window).mousemove(function(e){
+  $(window).mousemove(function(e) {
     pointerX = e.clientX;
     pointerY = e.clientY;
     showLog();
   });
 
   // 初期化
-  function init(){
+  function init() {
     lastPx = $(window).scrollTop();
     var distance = pixelToMetric(sumPx);
     var time = currentRecord(startTime);
@@ -58,17 +58,17 @@ $(function(){
     $('body').append(div);
   }
 
-  function cronItems(){
+  function cronItems() {
     // 100ミリ秒ごとに
-    timer = setInterval(function(){
+    timer = setInterval(function() {
       var time = currentRecord();
       $('#sm-time').text(time);
     }, 100);
 
     // スクロールごとに
-    $(window).scroll(function(){  
-      if(sumPx >= goalPx){
-        if(!stopTimeFlag){
+    $(window).scroll(function() {
+      if (sumPx >= goalPx) {
+        if (!stopTimeFlag) {
           var time = currentRecord();
           stopTime = time;
           stopTimeFlag = true;
@@ -78,7 +78,7 @@ $(function(){
       } else {
         var nowPx = $(window).scrollTop();
         var diff = nowPx - lastPx;
-        if (diff > 0 && diff < 50){
+        if (diff > 0 && diff < 50) {
           chrome.runtime.sendMessage({px: diff}, function(response) {
             var distance = pixelToMetric(response.sum);
             $('#sm-distance').text(distance);
@@ -89,20 +89,13 @@ $(function(){
     });
   }
 
-  chrome.runtime.onMessage.addListener(
-    function(request, sender, sendResponse) {
-      if (request.start === 'start'){
-        startTime = Date.parse(request.date);
-        sumPx = request.sum;
-        init();
-        cronItems(); 
-      }
+  chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+    if (request.start === 'start') {
+      startTime = Date.parse(request.date);
+      sumPx = request.sum;
+      init();
+      cronItems();
     }
-  );
+  });
 
 });
-
-
-
-
-


### PR DESCRIPTION
This PR depends on the PR https://github.com/ikeay/scroll-marathon/pull/1

There is no functional change in this PR. Just recommend using
`clang-format` to format the code automatically and
to keep the style consistent. You don't have to spend too much
time on manually tweaking the style via the text editors.
To format your code, e.g., "clang-format -i content.js". There might be
a bunch of plugins for running clang-format through IDEs on
the internet :)

The .clang-format file is the setting I came up based on your
coding style. (You can customize the setting if you want.)

You can install clang-format via Homebrew.
Hope this helps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ikeay/scroll-marathon/2)
<!-- Reviewable:end -->
